### PR TITLE
Try not to use ESM modules

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,4 +2,5 @@ module.exports = {
   future: {
     webpack5: false,
   },
+  experimental: { esmExternals: false }
 };


### PR DESCRIPTION
New vercel deployments will try to use ESM support with Next.js 12. This tells Vercel not to force enable ESM on Next.js 12.